### PR TITLE
Add step one and step two of onboarding pages and update styles of button

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -11,12 +11,14 @@ export default function Button(props: Props) {
   let textClassName = ''
   if (props.type === 'primary') {
     textClassName = 'text-m-sb'
-  } else {
+  } else if (props.type === 'secondary') {
     textClassName = 'text-m-r'
   }
   return (
     <button className={`${styles[props.type]}`} onClick={props.clickHandler}>
-      <span className={textClassName}>{props.text}</span>
+      <span className={`${textClassName} ${styles.buttonText}`}>
+        {props.text}
+      </span>
     </button>
   )
 }

--- a/pages/onboarding/step-1.tsx
+++ b/pages/onboarding/step-1.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router'
+import Image from 'next/image'
+import Button from '../../components/Button'
+import onboardingPage from '../../styles/OnboardingPage.module.css'
+import onboardingSupport from '../../public/assets/graphics/onboarding-support.svg'
+import stepOne from '../../public/assets/graphics/step-one.svg'
+
+export default function StepOne() {
+  const router = useRouter()
+
+  const navigateToNextStep = () => {
+    router.push('/onboarding/step-2')
+  }
+  return (
+    <div className={onboardingPage.pageWrapper}>
+      <div className={onboardingPage.container}>
+        <div className={onboardingPage.contentTop}>
+          <Image src={onboardingSupport} width={300} />
+          <p className={`${onboardingPage.textContainer} text-body-main-white`}>
+            From subsidy to vouchers, find the support you need from the list of
+            categories
+          </p>
+          <Image src={stepOne} />
+        </div>
+        <Button
+          type="secondary"
+          text="Next"
+          clickHandler={navigateToNextStep}
+        />
+      </div>
+    </div>
+  )
+}

--- a/pages/onboarding/step-2.tsx
+++ b/pages/onboarding/step-2.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router'
+import Image from 'next/image'
+import Button from '../../components/Button'
+import onboardingPage from '../../styles/OnboardingPage.module.css'
+import onboardingCard from '../../public/assets/graphics/onboarding-card.svg'
+import stepTwo from '../../public/assets/graphics/step-two.svg'
+
+export default function StepTwo() {
+  const router = useRouter()
+
+  const navigateToNextStep = () => {
+    router.push('/onboarding/step-1')
+  }
+  return (
+    <div className={onboardingPage.pageWrapper}>
+      <div className={onboardingPage.container}>
+        <div className={onboardingPage.contentTop}>
+          <Image src={onboardingCard} height={300} />
+          <p className="text-body-main-white">
+            Star your favorite support and find them quickly in your profile
+            next time!
+          </p>
+          <Image src={stepTwo} />
+        </div>
+        <Button
+          type="primary"
+          text="Get Started"
+          clickHandler={navigateToNextStep}
+        />
+      </div>
+    </div>
+  )
+}

--- a/pages/styles.tsx
+++ b/pages/styles.tsx
@@ -27,6 +27,7 @@ export default function Styles() {
         <ColorSwatch colorName="Font" colorVar="var(--accent-font)" />
         <ColorSwatch colorName="Black" colorVar="var(--accent-black)" />
         <ColorSwatch colorName="White" colorVar="var(--accent-White)" />
+        <ColorSwatch colorName="Offwhite" colorVar="var(--accent-offwhite)" />
         <ColorSwatch colorName="Link" colorVar="var(--accent-link)" />
         <ColorSwatch colorName="Disabled" colorVar="var(--accent-disabled)" />
         <ColorSwatch colorName="Success" colorVar="var(--accent-success)" />

--- a/public/assets/graphics/step-one.svg
+++ b/public/assets/graphics/step-one.svg
@@ -1,0 +1,4 @@
+<svg width="26" height="9" viewBox="0 0 26 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<ellipse cx="4" cy="4.05333" rx="4" ry="4.05333" fill="#8E3D57"/>
+<ellipse cx="22" cy="4.05333" rx="4" ry="4.05333" fill="#D8A190"/>
+</svg>

--- a/public/assets/graphics/step-two.svg
+++ b/public/assets/graphics/step-two.svg
@@ -1,0 +1,4 @@
+<svg width="26" height="9" viewBox="0 0 26 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<ellipse cx="4" cy="4.05333" rx="4" ry="4.05333" fill="#8E3D57"/>
+<ellipse cx="22" cy="4.05333" rx="4" ry="4.05333" fill="#8E3D57"/>
+</svg>

--- a/styles/Button.module.css
+++ b/styles/Button.module.css
@@ -15,7 +15,11 @@
 
 .secondary {
   composes: button;
-  background-color: var(--accent-white);
+  background-color: var(--accent-offwhite);
   color: var(--accent-label);
-  border: 1px solid var(--accent-label);
+  /* border: 1px solid var(--accent-label); */
+}
+
+.buttonText {
+  line-height: 0;
 }

--- a/styles/OnboardingPage.module.css
+++ b/styles/OnboardingPage.module.css
@@ -1,0 +1,29 @@
+.pageWrapper {
+  height: 100vh;
+  background-color: #f2b3be;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5%;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  text-align: center;
+  min-height: 560px;
+  height: 75%;
+}
+
+.contentTop {
+  height: 450px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.textContainer {
+  max-width: 500px;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -62,6 +62,7 @@ a {
   --accent-label: #d8a190;
   --accent-font: #737373;
   --accent-black: #333333;
+  --accent-offwhite: #f9f9f9;
   --accent-white: #ffffff;
   --accent-link: #0645ad;
   --accent-disabled: #929292;
@@ -118,6 +119,13 @@ h4 {
   font-family: 'Poppins', sans-serif;
   font-size: var(--fs-20);
   font-weight: var(--fw-regular);
+}
+
+.text-body-main-white {
+  font-family: 'Poppins', sans-serif;
+  font-size: var(--fs-20);
+  font-weight: var(--fw-regular);
+  color: var(--accent-white);
 }
 
 .text-m-r {


### PR DESCRIPTION
### Changes
- Change button component to more accurately reflect mockup
- Add new typography and colour to global stylesheet
- Add step one and step two of onboarding pages

### Testing
Onboarding pages can be accessed through the following paths:
- /onboarding/step-1
- /onboarding/step-2

### Remarks
Currently, the "Get Started" button in the Step Two page links back to the Step One page for ease of testing between the two screens. To be updated when screen for the next step is created.


### Screenshots
![image](https://user-images.githubusercontent.com/34487322/155364881-adad2431-1c5f-4c4e-badf-34ea8a6f4783.png)
*Page One*

![image](https://user-images.githubusercontent.com/34487322/155364634-1809decf-56d4-444d-a9e2-87c185ea1b9e.png)
*Page Two*